### PR TITLE
Fixes force drop always drop the same "Pearls of the Swine"

### DIFF
--- a/LastEpoch_Hud/Scripts/Hud_Manager.cs
+++ b/LastEpoch_Hud/Scripts/Hud_Manager.cs
@@ -3707,6 +3707,7 @@ namespace LastEpoch_Hud.Scripts
                                             {
                                                 string name = unique.displayName;
                                                 if (name == "") { name = unique.name; }
+                                                if (name == "Pearls of the Swine") { name = unique.name; } // if item's displayName is "Pearls of the Swine", use unique.name instead of unique.displayName
                                                 options.Add(new Dropdown.OptionData { text = name });
                                             }
                                         }


### PR DESCRIPTION
The unique amulet "Pearls of the Swine" have 3 variants, all have the same display name of "Pearls of the Swine".

Because of that, we can use `unique.name` instead of `unique.displayName` as drop down's item name for this amulet to prevent generating the same one 3 times.
