### PR TITLE
fixing Memory Amber dropping

### DIFF
--- a/LastEpoch_Hud/Scripts/Mods/Character/Character_MemoryAmber_Multiplier.cs
+++ b/LastEpoch_Hud/Scripts/Mods/Character/Character_MemoryAmber_Multiplier.cs
@@ -6,7 +6,7 @@ namespace LastEpoch_Hud.Scripts.Mods.Character
 {
     public class Character_MemoryAmber_Multiplier
     {
-        /*public static bool CanRun()
+        public static bool CanRun()
         {
             if ((Scenes.IsGameScene()) && (!Save_Manager.instance.IsNullOrDestroyed()) && (!Refs_Manager.player_actor.IsNullOrDestroyed()))
             {
@@ -20,13 +20,13 @@ namespace LastEpoch_Hud.Scripts.Mods.Character
         public class PickupableObjectsManager_CreatePickupableObjectForPlayer2
         {
             [HarmonyPrefix]
-            static void Prefix(ref uint __2)
+            static void Prefix(PickupableObjectType __0, ref uint __3)
             {
-                if (CanRun())
+                if (CanRun() && __0 == PickupableObjectType.MemoryAmber)
                 {
-                    __2 = Save_Manager.instance.data.Character.Cheats.MemoryAmberMultiplier * __2;
+                    __3 = Save_Manager.instance.data.Character.Cheats.MemoryAmberMultiplier * __3;
                 }
             }
-        }*/
+        }
     }
 }

--- a/LastEpoch_Hud/Scripts/Mods/Items/Items_AutoPickup_MemoryAmber.cs
+++ b/LastEpoch_Hud/Scripts/Mods/Items/Items_AutoPickup_MemoryAmber.cs
@@ -6,7 +6,7 @@ namespace LastEpoch_Hud.Scripts.Mods.Items
 {
     public class Items_AutoPickup_MemoryAmber
     {
-        /*public static bool CanRun()
+        public static bool CanRun()
         {
             if ((Scenes.IsGameScene()) && (!Save_Manager.instance.IsNullOrDestroyed()) && (!Refs_Manager.player_actor.IsNullOrDestroyed()))
             {
@@ -20,21 +20,21 @@ namespace LastEpoch_Hud.Scripts.Mods.Items
         public class PickupableObjectsManager_CreatePickupableObjectForPlayer2
         {
             [HarmonyPostfix]
-            static void Postfix(ref Il2CppLE.Factions.PickupableObjectsManager __instance, Il2CppLE.Factions.PickupableObjectSet __0, ref Vector3 __1, uint __2)
+            static void Postfix(ref Il2CppLE.Factions.PickupableObjectsManager __instance, Il2CppLE.Factions.PickupableObjectSet __1, ref Vector3 __2, uint __3)
             {
                 if (CanRun())
                 {
                     bool pick = false;
-                    System.UInt32 id = __0.NextID - 1;
-                    foreach (Il2CppSystem.Collections.Generic.KeyValuePair<Il2CppLE.Factions.PickupableObjectType, Il2CppSystem.Collections.Generic.List<Il2CppLE.Factions.PickupableObject>> obj in __0.pickupables)
+                    System.UInt32 id = __1.NextID - 1;
+                    foreach (Il2CppSystem.Collections.Generic.KeyValuePair<Il2CppLE.Factions.PickupableObjectType, Il2CppSystem.Collections.Generic.List<Il2CppLE.Factions.PickupableObject>> obj in __1.pickupables)
                     {
                         int index = 0;
                         foreach (Il2CppLE.Factions.PickupableObject pickupable_obj in obj.Value)
                         {
                             if (pickupable_obj.Id == id)
                             {
-                                __1 = Refs_Manager.player_actor.position();                                
-                                __instance.PickupObject(__0, pickupable_obj, index);
+                                __2 = Refs_Manager.player_actor.position();
+                                __instance.PickupObject(__1, pickupable_obj, index);
                                 pick = true;
                                 break;
                             }
@@ -44,6 +44,6 @@ namespace LastEpoch_Hud.Scripts.Mods.Items
                     }
                 }
             }
-        }*/
+        }
     }
 }


### PR DESCRIPTION
Fixing the Memory Amber drop and looting by adjusting the parameters order in the function.