### PR TITLE
Rewrite Skills_AutoCast to use game APIs, fix main menu freezing on load

### DIFF
--- a/LastEpoch_Hud/LastEpoch_Hud.csproj
+++ b/LastEpoch_Hud/LastEpoch_Hud.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
     <OutputType>Library</OutputType>
-	<Nullable>disable</Nullable>
+    <Nullable>disable</Nullable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <BaseOutputPath>..\Build</BaseOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -18,10 +18,12 @@
     <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
     <DefineConstants>WINGAMEPAD</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Keyboard|net6.0|AnyCPU'">
+  <PropertyGroup
+    Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Keyboard|net6.0|AnyCPU'">
     <DebugType>none</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='WinGamepad|net6.0|AnyCPU'">
+  <PropertyGroup
+    Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='WinGamepad|net6.0|AnyCPU'">
     <DebugType>none</DebugType>
   </PropertyGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
@@ -58,7 +60,8 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2CppSystem.IO.Compression.FileSystem">
-      <HintPath>$(LastEpochPath)\MelonLoader\Il2CppAssemblies\Il2CppSystem.IO.Compression.FileSystem.dll</HintPath>
+      <HintPath>
+        $(LastEpochPath)\MelonLoader\Il2CppAssemblies\Il2CppSystem.IO.Compression.FileSystem.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="Il2CppSystem.Numerics">
@@ -130,7 +133,8 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine">
-      <HintPath>$(LastEpochPath)\MelonLoader\Dependencies\Il2CppAssemblyGenerator\UnityDependencies\UnityEngine.dll</HintPath>
+      <HintPath>
+        $(LastEpochPath)\MelonLoader\Dependencies\Il2CppAssemblyGenerator\UnityDependencies\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="UnityEngine.AssetBundleModule">
@@ -167,7 +171,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Desktop.Robot" Version="1.5.0" />
     <PackageReference Include="Lib.Harmony" Version="2.3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/LastEpoch_Hud/LastEpoch_Hud.csproj
+++ b/LastEpoch_Hud/LastEpoch_Hud.csproj
@@ -7,13 +7,16 @@
     <BaseOutputPath>..\Build</BaseOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>Keyboard;WinGamepad</Configurations>
+    <Configuration Condition="'$(Configuration)' != 'WinGamepad'">Keyboard</Configuration>
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Keyboard|AnyCPU' ">
-  <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+  <PropertyGroup Condition="'$(Configuration)' != 'WinGamepad'">
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <DefineConstants>KEYBOARD</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'WinGamepad|AnyCPU' ">
-  <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+  <PropertyGroup Condition="'$(Configuration)' == 'WinGamepad'">
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <DefineConstants>WINGAMEPAD</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Keyboard|net6.0|AnyCPU'">
     <DebugType>none</DebugType>
@@ -207,7 +210,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(SkipPostBuild)' != 'true'">
     <Exec Command="call MakeLatest.bat" />
   </Target>
 </Project>

--- a/LastEpoch_Hud/Scripts/Hud_Manager.cs
+++ b/LastEpoch_Hud/Scripts/Hud_Manager.cs
@@ -247,7 +247,7 @@ namespace LastEpoch_Hud.Scripts
             if (!Refs_Manager.game_uibase.IsNullOrDestroyed())
             {
                 if ((game_canvas.IsNullOrDestroyed()) && (Refs_Manager.game_uibase.canvases.Count > 0)) { game_canvas = Refs_Manager.game_uibase.canvases[0]; }
-                if ((game_pause_menu.IsNullOrDestroyed()) || (Hud_Base.Default_PauseMenu_Btns.IsNullOrDestroyed())) { Hud_Base.Get_DefaultPauseMenu(); }
+                if (Scenes.IsGameScene() && ((game_pause_menu.IsNullOrDestroyed()) || (Hud_Base.Default_PauseMenu_Btns.IsNullOrDestroyed()))) { Hud_Base.Get_DefaultPauseMenu(); }
                 if ((!Hud_Base.initiliazed_events) && (!game_pause_menu.IsNullOrDestroyed()) && (!Hud_Base.Default_PauseMenu_Btns.IsNullOrDestroyed())) { Hud_Base.Set_Events(); }
                 if (Hud_Base.Get_DefaultPauseMenu_Open()) { Hud_Base.Toogle_DefaultPauseMenu(false); }
             }

--- a/LastEpoch_Hud/Scripts/Mods/Skills/Skills_AutoCast.cs
+++ b/LastEpoch_Hud/Scripts/Mods/Skills/Skills_AutoCast.cs
@@ -1,9 +1,6 @@
-﻿using Desktop.Robot;
-using Il2Cpp;
-using Il2CppPixelCrushers.DialogueSystem;
+﻿using Il2Cpp;
 using MelonLoader;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace LastEpoch_Hud.Scripts.Mods.Skills
 {
@@ -13,581 +10,291 @@ namespace LastEpoch_Hud.Scripts.Mods.Skills
         public static Skills_AutoCast instance { get; private set; }
         public Skills_AutoCast(System.IntPtr ptr) : base(ptr) { }
 
-        public static bool need_update = false;
-        public static bool updating = false;
-        public static PlayerSkill[] player_skills = new PlayerSkill[5];
-        public static bool[] autocast = { false, false, false, false, false };
-        public static bool[] channel_on_off = { false, false, false, false, false };
-        public static bool app_focus = true;
+        const int SlotCount = 5;
+
+        enum InitState { NeedsUpdate, Ready }
+
+        static InitState _state = InitState.NeedsUpdate;
+        static PlayerSkill[] _skills = new PlayerSkill[SlotCount];
+        static bool _appFocus = true;
+        static PlayerChargeManager _chargeManager;
+        static UseAbilityProcessor _useAbilityProcessor;
+        static Transform _playerTransform;
 
         void Awake()
         {
             instance = this;
-            need_update = true;
+            _state = InitState.NeedsUpdate;
         }
+
         void Update()
         {
-            if (Scenes.IsGameScene())
+            if (!Scenes.IsGameScene())
             {
-                if ((need_update) && (!updating))
-                {
-                    updating = true;
-                    need_update = false;
-                    player_skills = new PlayerSkill[5];
-
-                    GameObject ability_0 = null;
-                    GameObject ability_1 = null;
-                    GameObject ability_2 = null;
-                    GameObject ability_3 = null;
-                    GameObject ability_4 = null;
-                    //if (!Refs_Manager.player_data.IsNullOrDestroyed()) { character_name = Refs_Manager.player_data.CharacterName; }
-                    if (!Refs_Manager.game_uibase.IsNullOrDestroyed())
-                    {
-                        Canvas canvas_bottom = null;
-                        foreach (Canvas canvas in Refs_Manager.game_uibase.canvases)
-                        {
-                            if (canvas.name == "Canvas (bottom screen UI)")
-                            {
-                                canvas_bottom = canvas;
-                                break;
-                            }
-                        }
-                        if (!canvas_bottom.IsNullOrDestroyed())
-                        {
-                            GameObject holder = Functions.GetChild(canvas_bottom.gameObject, "Bottom Screen UI Holder");
-                            if (!holder.IsNullOrDestroyed())
-                            {
-                                GameObject screen_ui = Functions.GetChild(holder, "Bottom Screen UI(Clone)");
-                                if (!screen_ui.IsNullOrDestroyed())
-                                {
-                                    GameObject actionBar = Functions.GetChild(screen_ui, "actionBar");
-                                    if (!actionBar.IsNullOrDestroyed())
-                                    {
-                                        GameObject actionBar_middle = Functions.GetChild(actionBar, "ActionBarMiddle");
-                                        if (!actionBar_middle.IsNullOrDestroyed())
-                                        {
-                                            GameObject input_abilities = Functions.GetChild(actionBar_middle, "Inputs_Abilities");
-                                            if (!input_abilities.IsNullOrDestroyed())
-                                            {
-                                                ability_0 = Functions.GetChild(input_abilities, "ActionBarAbility");
-                                                ability_1 = Functions.GetChild(input_abilities, "ActionBarAbility (1)");
-                                                ability_2 = Functions.GetChild(input_abilities, "ActionBarAbility (2)");
-                                                ability_3 = Functions.GetChild(input_abilities, "ActionBarAbility (3)");
-                                                ability_4 = Functions.GetChild(input_abilities, "ActionBarAbility (4)");
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    if (!ability_0.IsNullOrDestroyed())
-                    {
-                        Sprite sprite = GetIcon(ability_0);
-                        string name = GetName(sprite);
-                        player_skills[0] = new PlayerSkill
-                        {
-                            go = ability_0,
-                            ability = GetAbility(sprite),
-                            key = GetKeyBind(ability_0),
-                            channeled = GetIsChanneled(name),
-                            instant = GetIsInstant(name),
-                            channel_with_robot = false
-                        };
-                    }
-                    if (!ability_1.IsNullOrDestroyed())
-                    {
-                        Sprite sprite = GetIcon(ability_1);
-                        string name = GetName(sprite);
-                        player_skills[1] = new PlayerSkill
-                        {
-                            go = ability_1,
-                            ability = GetAbility(sprite),
-                            key = GetKeyBind(ability_1),
-                            channeled = GetIsChanneled(name),
-                            instant = GetIsInstant(name),
-                            channel_with_robot = false
-                        };
-                    }
-                    if (!ability_2.IsNullOrDestroyed())
-                    {
-                        Sprite sprite = GetIcon(ability_2);
-                        string name = GetName(sprite);
-                        player_skills[2] = new PlayerSkill
-                        {
-                            go = ability_2,
-                            ability = GetAbility(sprite),
-                            key = GetKeyBind(ability_2),
-                            channeled = GetIsChanneled(name),
-                            instant = GetIsInstant(name),
-                            channel_with_robot = false
-                        };
-                    }
-                    if (!ability_3.IsNullOrDestroyed())
-                    {
-                        Sprite sprite = GetIcon(ability_3);
-                        string name = GetName(sprite);
-                        player_skills[3] = new PlayerSkill
-                        {
-                            go = ability_3,
-                            ability = GetAbility(sprite),
-                            key = GetKeyBind(ability_3),
-                            channeled = GetIsChanneled(name),
-                            instant = GetIsInstant(name),
-                            channel_with_robot = false
-                        };
-                    }
-                    if (!ability_4.IsNullOrDestroyed())
-                    {
-                        Sprite sprite = GetIcon(ability_4);
-                        string name = GetName(sprite);
-                        player_skills[4] = new PlayerSkill
-                        {
-                            go = ability_4,
-                            ability = GetAbility(sprite),
-                            key = GetKeyBind(ability_4),
-                            channeled = GetIsChanneled(name),
-                            instant = GetIsInstant(name),
-                            channel_with_robot = false
-                        };
-                    }
-                    updating = false;
-                }
-                if (!need_update)
-                {
-                    for (int i = 0; i < 5; i++)
-                    {
-                        if (player_skills[i].key != KeyCode.None)
-                        {
-#if KEYBOARD
-                            Event e = Event.current;
-                            if ((e.type == EventType.KeyUp) && (e.keyCode == player_skills[i].key))
-                            {
-                                if (player_skills[i].channeled)
-                                {
-                                    bool enable = channel_on_off[i];
-                                    if (e.control) { channel_on_off[i] = !enable; }
-                                    else if (channel_on_off[i]) { channel_on_off[i] = false; }
-                                    if ((!channel_on_off[i]) && (player_skills[i].channel_with_robot)) { player_skills[i].channel_with_robot = false; }
-                                }
-                                else if (e.control)
-                                {
-                                    bool enable = autocast[i];
-                                    autocast[i] = !enable;
-                                }
-                            }
-#endif
-                            if ((autocast[i]) &&                                        //Autocast On
-                            (!GetIsOnCooldown(player_skills[i].go)) &&                  //Not on cooldown
-                            (!GetIsOutOfMana(player_skills[i].go)) &&                   //Not out of mana
-                            (app_focus))                                                //Application is focused
-                            {
-                                Robot robot = new Robot();
-                                Key robot_key = GetRobotKey(player_skills[i].key);
-                                if (robot_key != Key.Pause) { robot.KeyPress(robot_key); }
-                            }
-                            if (channel_on_off[i])
-                            {
-                                if (!player_skills[i].channel_with_robot)                   //DoOnce
-                                {
-                                    Robot robot = new Robot();
-                                    Key robot_key = GetRobotKey(player_skills[i].key);
-                                    if (robot_key != Key.Pause)
-                                    {
-                                        player_skills[i].channel_with_robot = true;
-                                        robot.KeyDown(robot_key);
-                                    }
-                                }
-                                else if (!app_focus)
-                                {
-                                    Robot robot = new Robot();
-                                    Key robot_key = GetRobotKey(player_skills[i].key);
-                                    if (robot_key != Key.Pause)
-                                    {
-                                        player_skills[i].channel_with_robot = false;
-                                        robot.KeyUp(robot_key);
-                                    }
-                                }
-                            }
-                            else { player_skills[i].channel_with_robot = false; }
-                        }
-                    }
-                }
+                _state = InitState.NeedsUpdate;
+                return;
             }
-            else { need_update = true; }
+
+            if (_state == InitState.NeedsUpdate)
+                InitializeSkills();
+
+            if (_state != InitState.Ready)
+                return;
+
+            CacheRefs();
+            if (_useAbilityProcessor == null || _useAbilityProcessor.IsNullOrDestroyed())
+                return;
+
+            bool anyActive = false;
+            for (int i = 0; i < SlotCount; i++)
+            {
+                if (_skills[i].ability.IsNullOrDestroyed())
+                    continue;
+
+                HandleInput(i);
+                if (_skills[i].autocast || _skills[i].channel_on || _skills[i].channeling_active)
+                    anyActive = true;
+            }
+
+            if (!anyActive)
+                return;
+
+            Vector3 targetPos = GetTargetPosition(out Transform hitTransform);
+
+            for (int i = 0; i < SlotCount; i++)
+            {
+                if (_skills[i].ability.IsNullOrDestroyed())
+                    continue;
+
+                HandleAutoCast(i, targetPos, hitTransform);
+                HandleChanneling(i, targetPos, hitTransform);
+            }
         }
+
         void OnApplicationFocus(bool hasFocus)
         {
-            app_focus = hasFocus;
+            _appFocus = hasFocus;
         }
 
         public struct PlayerSkill
         {
-            public GameObject go;
             public Ability ability;
             public KeyCode key;
             public bool channeled;
-            public bool instant;
-            public bool channel_with_robot;
+            public bool autocast;
+            public bool channel_on;
+            public bool channeling_active;
         }
-        Sprite GetIcon(GameObject go)
+
+        void InitializeSkills()
         {
-            Sprite result = null;
-            if (!go.IsNullOrDestroyed())
+            _skills = new PlayerSkill[SlotCount];
+
+            if (Refs_Manager.player_treedata.IsNullOrDestroyed()) { _state = InitState.Ready; return; }
+
+            var abilityList = Refs_Manager.player_treedata.playerAbilityList;
+            if (abilityList.IsNullOrDestroyed()) { _state = InitState.Ready; return; }
+
+            var actionBarSlots = FindActionBarSlots();
+
+            for (int i = 0; i < SlotCount; i++)
             {
-                GameObject icon = Functions.GetChild(go, "AbilityIcon1");
-                if (!icon.IsNullOrDestroyed())
+                Ability ability = null;
+                try { ability = abilityList.getAbility(i); } catch { }
+                if (ability.IsNullOrDestroyed()) continue;
+
+                KeyCode key = KeyCode.None;
+                if (actionBarSlots != null && !actionBarSlots[i].IsNullOrDestroyed())
+                    key = GetKeyBind(actionBarSlots[i]);
+
+                _skills[i] = new PlayerSkill
                 {
-                    GameObject sprite = Functions.GetChild(icon, "Sprite");
-                    if (!sprite.IsNullOrDestroyed())
-                    {
-                        if (sprite.active)
-                        {
-                            Image sprite_image = sprite.GetComponent<Image>();
-                            result = sprite_image.sprite;
-                        }
-                    }
+                    ability = ability,
+                    key = key,
+                    channeled = ability.channelled
+                };
+            }
+
+            _state = InitState.Ready;
+        }
+
+        void CacheRefs()
+        {
+            if (!_chargeManager.IsNullOrDestroyed() &&
+                !(_useAbilityProcessor == null || _useAbilityProcessor.IsNullOrDestroyed()) &&
+                !_playerTransform.IsNullOrDestroyed())
+                return;
+
+            if (!Refs_Manager.player_actor.IsNullOrDestroyed())
+            {
+                if (_chargeManager.IsNullOrDestroyed())
+                {
+                    try { _chargeManager = Refs_Manager.player_actor.GetComponent<PlayerChargeManager>(); }
+                    catch { }
+                }
+                if (_playerTransform.IsNullOrDestroyed())
+                {
+                    try { _playerTransform = Refs_Manager.player_actor.transform; }
+                    catch { }
                 }
             }
-            return result;
-        }
-        bool GetIsOnCooldown(GameObject go)
-        {
-            bool result = false;
-            if (!go.IsNullOrDestroyed())
+
+            if (_useAbilityProcessor == null || _useAbilityProcessor.IsNullOrDestroyed())
             {
-                GameObject icon = Functions.GetChild(go, "AbilityIcon1");
-                if (!icon.IsNullOrDestroyed())
+                if (!Refs_Manager.epoch_input_manager.IsNullOrDestroyed())
                 {
-                    GameObject cooldown = Functions.GetChild(icon, "CooldownBar");
-                    if (!cooldown.IsNullOrDestroyed())
-                    {
-                        if (cooldown.activeSelf)
-                        {
-                            Image cooldown_image = cooldown.GetComponent<Image>();
-                            if (!cooldown_image.IsNullOrDestroyed())
-                            {
-                                if (cooldown_image.fillAmount > 0f) { result = true; }
-                            }
-                        }
-                    }
+                    try { _useAbilityProcessor = Refs_Manager.epoch_input_manager.useAbilityProcessor; }
+                    catch { }
                 }
             }
-            return result;
         }
-        bool GetIsOutOfMana(GameObject go)
+
+        void HandleInput(int i)
         {
-            bool result = false;
-            if (!go.IsNullOrDestroyed())
+#if KEYBOARD
+            if (_skills[i].key == KeyCode.None) return;
+            if (!Input.GetKeyUp(_skills[i].key)) return;
+
+            bool ctrl = Input.GetKey(KeyCode.LeftControl) || Input.GetKey(KeyCode.RightControl);
+
+            if (_skills[i].channeled)
             {
-                GameObject icon = Functions.GetChild(go, "AbilityIcon1");
-                if (!icon.IsNullOrDestroyed())
-                {
-                    GameObject mana = Functions.GetChild(icon, "OutOfMana");
-                    if (!mana.IsNullOrDestroyed())
-                    {
-                        if (mana.activeSelf) { result = true; }
-                    }
-                }
+                if (ctrl)
+                    _skills[i].channel_on = !_skills[i].channel_on;
+                else if (_skills[i].channel_on)
+                    _skills[i].channel_on = false;
+
+                if (!_skills[i].channel_on && _skills[i].channeling_active)
+                    _skills[i].channeling_active = false;
             }
-            return result;
+            else if (ctrl)
+            {
+                _skills[i].autocast = !_skills[i].autocast;
+            }
+#endif
         }
+
+        void HandleAutoCast(int i, Vector3 targetPos, Transform hitTransform)
+        {
+            if (!_skills[i].autocast || !_appFocus) return;
+            if (IsOnCooldown(_skills[i].ability)) return;
+
+            try { _useAbilityProcessor.UseBarAbilityCommand(true, i + 1, -1, targetPos, hitTransform, false); }
+            catch { }
+        }
+
+        void HandleChanneling(int i, Vector3 targetPos, Transform hitTransform)
+        {
+            if (!_skills[i].channel_on)
+            {
+                if (_skills[i].channeling_active)
+                {
+                    _skills[i].channeling_active = false;
+                    try { _useAbilityProcessor.UseBarAbilityCommand(false, i + 1, -1, targetPos, hitTransform, false); }
+                    catch { }
+                }
+                return;
+            }
+
+            if (!_skills[i].channeling_active)
+            {
+                _skills[i].channeling_active = true;
+                try { _useAbilityProcessor.UseBarAbilityCommand(true, i + 1, -1, targetPos, hitTransform, false); }
+                catch { }
+            }
+            else if (!_appFocus)
+            {
+                _skills[i].channeling_active = false;
+                _skills[i].channel_on = false;
+                try { _useAbilityProcessor.UseBarAbilityCommand(false, i + 1, -1, targetPos, hitTransform, false); }
+                catch { }
+            }
+        }
+
+        bool IsOnCooldown(Ability ability)
+        {
+            if (_chargeManager.IsNullOrDestroyed()) return false;
+            try { return _chargeManager.onCoooldown(ability); }
+            catch { return false; }
+        }
+
+        static Vector3 GetTargetPosition(out Transform hitTransform)
+        {
+            hitTransform = null;
+            if (_playerTransform.IsNullOrDestroyed())
+                return Vector3.zero;
+
+            try
+            {
+                Vector3 pos = MouseManager.AbilityUseMousePoint(
+                    out hitTransform, out _, false, _playerTransform);
+                return pos;
+            }
+            catch
+            {
+                return _playerTransform.position;
+            }
+        }
+
+        GameObject[] FindActionBarSlots()
+        {
+            if (Refs_Manager.game_uibase.IsNullOrDestroyed()) return null;
+
+            Canvas canvas = FindBottomCanvas();
+            if (canvas.IsNullOrDestroyed()) return null;
+
+            GameObject inputAbilities = NavigateTo(canvas.gameObject,
+                "Bottom Screen UI Holder", "Bottom Screen UI(Clone)",
+                "actionBar", "ActionBarMiddle", "Inputs_Abilities");
+            if (inputAbilities.IsNullOrDestroyed()) return null;
+
+            return new[]
+            {
+                Functions.GetChild(inputAbilities, "ActionBarAbility"),
+                Functions.GetChild(inputAbilities, "ActionBarAbility (1)"),
+                Functions.GetChild(inputAbilities, "ActionBarAbility (2)"),
+                Functions.GetChild(inputAbilities, "ActionBarAbility (3)"),
+                Functions.GetChild(inputAbilities, "ActionBarAbility (4)")
+            };
+        }
+
+        Canvas FindBottomCanvas()
+        {
+            foreach (Canvas canvas in Refs_Manager.game_uibase.canvases)
+            {
+                if (canvas.name == "Canvas (bottom screen UI)")
+                    return canvas;
+            }
+            return null;
+        }
+
+        GameObject NavigateTo(GameObject root, params string[] path)
+        {
+            GameObject current = root;
+            foreach (string name in path)
+            {
+                current = Functions.GetChild(current, name);
+                if (current.IsNullOrDestroyed()) return null;
+            }
+            return current;
+        }
+
         KeyCode GetKeyBind(GameObject go)
         {
-            KeyCode result = KeyCode.None;
-            if (!go.IsNullOrDestroyed())
-            {
-                GameObject input = Functions.GetChild(go, "Ability Input Character");
-                if (!input.IsNullOrDestroyed())
-                {
-                    Il2CppTMPro.TextMeshProUGUI keybind_text = input.GetComponent<Il2CppTMPro.TextMeshProUGUI>();
-                    if (!keybind_text.IsNullOrDestroyed())
-                    {
-                        switch (keybind_text.text)
-                        {
-                            case "A": result = KeyCode.A; break;
-                            case "B": result = KeyCode.B; break;
-                            case "C": result = KeyCode.C; break;
-                            case "D": result = KeyCode.D; break;
-                            case "E": result = KeyCode.E; break;
-                            case "F": result = KeyCode.F; break;
-                            case "G": result = KeyCode.G; break;
-                            case "H": result = KeyCode.H; break;
-                            case "I": result = KeyCode.I; break;
-                            case "J": result = KeyCode.J; break;
-                            case "K": result = KeyCode.K; break;
-                            case "L": result = KeyCode.L; break;
-                            case "M": result = KeyCode.M; break;
-                            case "N": result = KeyCode.N; break;
-                            case "O": result = KeyCode.O; break;
-                            case "P": result = KeyCode.P; break;
-                            case "Q": result = KeyCode.Q; break;
-                            case "R": result = KeyCode.R; break;
-                            case "S": result = KeyCode.S; break;
-                            case "T": result = KeyCode.T; break;
-                            case "U": result = KeyCode.U; break;
-                            case "V": result = KeyCode.V; break;
-                            case "W": result = KeyCode.W; break;
-                            case "X": result = KeyCode.X; break;
-                            case "Y": result = KeyCode.Y; break;
-                            case "Z": result = KeyCode.Z; break;
-                        }
-                    }
-                }
-            }
-            return result;
-        }
-        string GetName(Sprite sprite)
-        {
-            string result = "";
-            if (!sprite.IsNullOrDestroyed())
-            {
-                try
-                {
-                    foreach (Ability ability in Refs_Manager.player_treedata.playerAbilityList.equippedAbilities)
-                    {
-                        if (!ability.IsNullOrDestroyed())
-                        {
-                            if (sprite == ability.abilitySprite)
-                            {
-                                result = ability.abilityName;
-                                break;
-                            }
-                        }
-                    }
-                }
-                catch { }
-            }
-            return result;
-        }
-        Ability GetAbility(Sprite sprite)
-        {
-            Ability result = null;
-            if (!sprite.IsNullOrDestroyed())
-            {
-                try
-                {
-                    foreach (Ability ability in Refs_Manager.player_treedata.playerAbilityList.equippedAbilities)
-                    {
-                        if (!ability.IsNullOrDestroyed())
-                        {
-                            if (sprite == ability.abilitySprite)
-                            {
-                                result = ability;
-                                break;
-                            }
-                        }
-                    }
-                }
-                catch { }
-            }
-            return result;
-        }
-        bool GetIsChanneled(string name)
-        {
-            bool result = false;
-            if (name != "")
-            {
-                try
-                {
-                    foreach (Ability ability in Refs_Manager.player_treedata.playerAbilityList.equippedAbilities)
-                    {
-                        if (!ability.IsNullOrDestroyed())
-                        {
-                            if (name == ability.abilityName)
-                            {
-                                result = ability.channelled;
-                                break;
-                            }
-                        }
-                    }
-                }
-                catch { }
-            }
-            return result;
-        }
-        bool GetIsInstant(string name)
-        {
-            bool result = false;
-            if (name != "")
-            {
-                try
-                {
-                    foreach (Ability ability in Refs_Manager.player_treedata.playerAbilityList.equippedAbilities)
-                    {
-                        if (!ability.IsNullOrDestroyed())
-                        {
-                            if (name == ability.abilityName)
-                            {
-                                result = ability.instantCastForPlayer;
-                                break;
-                            }
-                        }
-                    }
-                }
-                catch { }
-            }
-            return result;
-        }
-        Key GetRobotKey(KeyCode key)
-        {
-            Key result = Key.Pause;
-            switch (key)
-            {
-                case KeyCode.A:
-                    result = Key.A;
-                    break;
-                case KeyCode.B:
-                    result = Key.B;
-                    break;
-                case KeyCode.C:
-                    result = Key.C;
-                    break;
-                case KeyCode.D:
-                    result = Key.D;
-                    break;
-                case KeyCode.E:
-                    result = Key.E;
-                    break;
-                case KeyCode.F:
-                    result = Key.F;
-                    break;
-                case KeyCode.G:
-                    result = Key.G;
-                    break;
-                case KeyCode.H:
-                    result = Key.H;
-                    break;
-                case KeyCode.I:
-                    result = Key.I;
-                    break;
-                case KeyCode.J:
-                    result = Key.J;
-                    break;
-                case KeyCode.K:
-                    result = Key.K;
-                    break;
-                case KeyCode.L:
-                    result = Key.L;
-                    break;
-                case KeyCode.M:
-                    result = Key.M;
-                    break;
-                case KeyCode.N:
-                    result = Key.N;
-                    break;
-                case KeyCode.O:
-                    result = Key.O;
-                    break;
-                case KeyCode.P:
-                    result = Key.P;
-                    break;
-                case KeyCode.Q:
-                    result = Key.Q;
-                    break;
-                case KeyCode.R:
-                    result = Key.R;
-                    break;
-                case KeyCode.S:
-                    result = Key.S;
-                    break;
-                case KeyCode.T:
-                    result = Key.T;
-                    break;
-                case KeyCode.U:
-                    result = Key.U;
-                    break;
-                case KeyCode.V:
-                    result = Key.V;
-                    break;
-                case KeyCode.W:
-                    result = Key.W;
-                    break;
-                case KeyCode.X:
-                    result = Key.X;
-                    break;
-                case KeyCode.Y:
-                    result = Key.Y;
-                    break;
-                case KeyCode.Z:
-                    result = Key.Z;
-                    break;
-            }
+            if (go.IsNullOrDestroyed()) return KeyCode.None;
 
-            return result;
+            GameObject input = Functions.GetChild(go, "Ability Input Character");
+            if (input.IsNullOrDestroyed()) return KeyCode.None;
+
+            var keybindText = input.GetComponent<Il2CppTMPro.TextMeshProUGUI>();
+            if (keybindText.IsNullOrDestroyed()) return KeyCode.None;
+
+            string text = keybindText.text;
+            if (text.Length == 1 && char.IsLetter(text[0]) &&
+                System.Enum.TryParse<KeyCode>(text.ToUpper(), out var key))
+                return key;
+
+            return KeyCode.None;
         }
-
-        /*[HarmonyPatch(typeof(AbilityBarIcon), "Pressed")]
-        public class AbilityBarIcon_Pressed
-        {
-            [HarmonyPostfix]
-            static void Postfix(ref AbilityBarIcon __instance)
-            {
-                for (int i = 0; i < 5; i++)
-                {
-                    if (player_skills[i].channeled)
-                    {
-                        AbilityBarIcon abicon = Functions.GetChild(player_skills[i].go, "AbilityIcon1").GetComponent<AbilityBarIcon>();
-                        if (!abicon.IsNullOrDestroyed())
-                        {
-                            if (abicon == __instance)
-                            {
-                                bool enable = channel_started[i];
-                                channel_started[i] = !enable;
-                                Main.logger_instance.Msg("channel_started[" + i + "] set to " + channel_started[i]);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }*/
-
-        /*[HarmonyPatch(typeof(CharacterMutator), "OnStartedUsingAbility")]
-        public class CharacterMutator_OnStartedUsingAbility
-        {
-            [HarmonyPostfix]
-            static void Postfix(ref AbilityInfo __0, Ability __1)
-            {
-                for (int i = 0; i < 5; i++)
-                {
-                    if (player_skills[i].ability == __1)
-                    {
-                        player_skills[i].abilityInfo = __0;
-                        if (player_skills[i].channeled)
-                        {
-                            bool enable = channel_started[i];
-                            channel_started[i] = !enable;
-                            Main.logger_instance.Msg("channel_started[" + i + "] set to " + channel_started[i]);
-                        }
-                        break;
-                    }
-                }
-            }
-        }
-
-        [HarmonyPatch(typeof(CharacterMutator), "OnStoppedUsingAbility")]
-        public class CharacterMutator_OnStoppedUsingAbility
-        {
-            [HarmonyPrefix]
-            static bool Prefix(ref AbilityInfo __0)
-            {
-                bool result = true;
-                for (int i = 0; i < 5; i++)
-                {
-                    if (player_skills[i].abilityInfo == __0)
-                    {
-                        if (channel_started[i])
-                        {
-                            result = false;
-                            Main.logger_instance.Msg("alter OnStoppedUsingAbility");
-                        }
-                        break;
-                    }
-                }
-
-                return result;
-            }
-        }*/
     }
 }


### PR DESCRIPTION
- **Rewrote Skills_AutoCast**, I basically ripped out Desktop.Robot keyboard simulation and replaced it with direct calls to UseAbilityProcessor.UseBarAbilityCommand(). Also cut out some deeply nested logic, file size went down roughly in half. Should also use the targeting system used in-game, and not break the flow when user starts using other menus or typing something.
- **Fixed game freezing on the main menu**, Hud_Base.Get_DefaultPauseMenu() was getting called every frame outside game scenes, which hung the game, I just wrapped it in a Scenes.IsGameScene() check
- **Fixed dotnet build failing without -c**, so basically running a bare dotnet build would error out because the csproj didn't know what to do without an explicit configuration. I made it default to Keyboard and also added a SkipPostBuild (just for dev purposes for faster builds). Mostly interesting when not using Visual Studio and instead making use of VSCode for .NET development