### PR TITLE
Handle missing ConfigureTabUI.OnEnable and visual lookup exceptions

### DIFF
--- a/LastEpoch_Hud/Scripts/Mods/Bank/Bank_Quad.cs
+++ b/LastEpoch_Hud/Scripts/Mods/Bank/Bank_Quad.cs
@@ -512,6 +512,15 @@ namespace LastEpoch_Hud.Scripts.Mods.Bank
             [HarmonyPatch(typeof(ConfigureTabUI), "OnEnable")]
             public class ConfigureTabUI_OnEnable
             {
+                [HarmonyPrepare]
+                static bool Prepare()
+                {
+                    bool found = AccessTools.DeclaredMethod(typeof(ConfigureTabUI), "OnEnable") != null;
+                    if (!found)
+                        MelonLogger.Warning("ConfigureTabUI.OnEnable not found, skipping Quad Stash config UI patch");
+                    return found;
+                }
+
                 [HarmonyPrefix]
                 static void Prefix(ref ConfigureTabUI __instance)
                 {

--- a/LastEpoch_Hud/Scripts/Mods/NewItems/Items_SandsOfSilk.cs
+++ b/LastEpoch_Hud/Scripts/Mods/NewItems/Items_SandsOfSilk.cs
@@ -1,4 +1,5 @@
-﻿using HarmonyLib;
+﻿using System;
+using HarmonyLib;
 using Il2Cpp;
 using Il2CppLE.Services.Models.Items;
 using Il2CppLE.Services.Visuals;
@@ -390,6 +391,14 @@ namespace LastEpoch_Hud.Scripts.Mods.NewItems
                         __0.SubType = 0;
                         __0.UniqueID = 7; //The Krestel
                     }
+                }
+
+                [HarmonyFinalizer]
+                static Exception Finalizer(Exception __exception)
+                {
+                    if (__exception != null)
+                        MelonLogger.Warning($"GetItemVisual threw: {__exception.GetType().Name}");
+                    return null;
                 }
             }
         }


### PR DESCRIPTION
Harmony creates a managed trampoline for `GetItemVisual()`. Native exceptions that the game normally catches internally now cross the managed boundary and become fatal `Il2CppException`. Fix is to create a `[HarmonyFinalizer]` which would technically return null to original caller instead of crashing the app (probably triggering original game fallback behavior)