### PR TITLE
Avoid softlock with auto pickup gathering tutorial items

### DIFF
--- a/LastEpoch_Hud/Scripts/Mods/Items/Items_AutoPickup_Items.cs
+++ b/LastEpoch_Hud/Scripts/Mods/Items/Items_AutoPickup_Items.cs
@@ -137,7 +137,11 @@ namespace LastEpoch_Hud.Scripts.Mods.Items
                     {
                         __1.rarity = 4;
                         __1.RefreshIDAndValues();
-                    }                   
+                    }
+                    // Tutorial items advance their quest objective
+                    // only through the natural GroundItemManager.pickupItem path. Skip auto-pickup so the
+                    // player's manual pickup fires CheckItemRelatedObjectives and avoids a softlock.
+                    if (__1 != null && __1.isTutorialItem()) { return true; }
                     ItemDataUnpacked item = __1.TryCast<ItemDataUnpacked>();
                     if ((!Save_Manager.instance.IsNullOrDestroyed()) && (!item.IsNullOrDestroyed()))
                     {


### PR DESCRIPTION
**Requires build after merge**

Affects "Forge Basics I" quest
[retrieve the affix shards]

If user softlocked before this patch, try installing yukieiji fork of Unity Explorer
https://github.com/yukieiji/UnityExplorer

In game open Unity Console and execute command:
`Il2Cpp.CraftingObjectivesAndQuests.Instance.PickupAffixShards.completeObjectiveNoNotification();`